### PR TITLE
Adding optional constructor param to inject an instance of a ServiceFactory

### DIFF
--- a/src/Artdarek/OAuth/OAuth.php
+++ b/src/Artdarek/OAuth/OAuth.php
@@ -24,11 +24,12 @@ class OAuth
 
     /**
      * Constructor
-     * 
-     * @param ServiceFactory $service_factory Optional dependency injection. 
+     *
+     * @param ServiceFactory $serviceFactory Optional dependency injection.
      *     If not provided, a ServiceFactory instance will be constructed.
      */
-    public function __construct(ServiceFactory $serviceFactory = null) {
+    public function __construct(ServiceFactory $serviceFactory = null)
+    {
 
         if (null === $serviceFactory) {
             // Create the service factory
@@ -36,8 +37,7 @@ class OAuth
         }
 
         $this->serviceFactory = $serviceFactory;
-
-    } 
+    }
 
     /**
      * Create storage instance


### PR DESCRIPTION
The ability to register custom services to PHPOAuthLib was added last year (see: Lusitanian/PHPoAuthLib#103)

This pull request allows the user to inject an instance of `ServiceFactory` into this library's `OAuth` class to support the above functionality. To maintain BC, the `ServiceFactory` object is not required and by default it will instantiate a new one, as it currently does.
