### PR TITLE
better way to have the config files in different environments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ Use composer to install this package.
 $ composer update
 ```
 
-Create configuration file using artisan
-
-```
-$ php artisan config:publish artdarek/oauth-4-laravel
-```
-
 ## Configuration
 
 ### Registering the Package
@@ -80,7 +74,11 @@ and register this service provider at the bottom of the `$providers` array:
 
 ### Credentials
 
-Add your credentials to ``app/config/packages/artdarek/oauth-4-laravel/config.php``
+Create a config file ``app/config/oauth-4-laravel.php`` and add your credentials
+
+if you need different configs for different environments create the config file 
+for each environment you want, like ``app/config/production/oauth-4-laravel.php``
+or ``app/config/staging/oauth-4-laravel.php``
 
 ```php
 return array( 

--- a/src/Artdarek/OAuth/OAuth.php
+++ b/src/Artdarek/OAuth/OAuth.php
@@ -74,13 +74,13 @@ class OAuth
     public function consumer( $service, $url = null, $scope = null ) 
     {
         // get storage object
-        $storage_name = Config::get('oauth-4-laravel::storage', 'Session');
+        $storage_name = Config::get('oauth-4-laravel.storage', 'Session');
         $storage = $this->createStorageInstance( $storage_name );
 
         // create credentials object
         $credentials = new Credentials(
-            Config::get("oauth-4-laravel::consumers.$service.client_id"),
-            Config::get("oauth-4-laravel::consumers.$service.client_secret"),
+            Config::get("oauth-4-laravel.consumers.$service.client_id"),
+            Config::get("oauth-4-laravel.consumers.$service.client_secret"),
             $url ?: URL::current()
         );
 
@@ -88,7 +88,7 @@ class OAuth
         if (is_null($scope))
         {
             // get scope from config (default to empty array)
-            $scope = Config::get("oauth-4-laravel::consumers.$service.scope", array() );
+            $scope = Config::get("oauth-4-laravel.consumers.$service.scope", array() );
         }
 
         // return the service consumer object


### PR DESCRIPTION
The user can run the artisan command, generate the package folder with the config and create the environment folder inside package, but sometimes, it's easy for the user to just create the config file in the config folder with the several environments and keep this file versioned. And in this way, it gets easier because the user doesn't have to remember another artisan command when deploy the project.

I hope it helps ... and thanks for sharing this oAuth Class!
