### PR TITLE
Use lusitanian/oauth 0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": ">=5.3",     
-        "lusitanian/oauth": "0.2.*"
+        "lusitanian/oauth": "0.3.*"
     },
     "require-dev": {
         "illuminate/support": "4.0.*"


### PR DESCRIPTION
lusitanian/oauth was bumped to 0.3 last week.

Google has changed the names of their scopes and deprecated the existing ones, the bump to 0.3 addresses this change: https://developers.google.com/+/api/oauth#login-scopes
