### PR TITLE
Added additional session driver to tie into Laravel's sessions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ return array(
 Add your credentials to ``app/config/packages/artdarek/oauth-4-laravel/config.php`` or ``app/config/oauth-4-laravel.php`` (depending on which option of configuration you choose)
 
 
-The `Storage` attribute is optional and defaults to `Session`. 
-Other [options](https://github.com/Lusitanian/PHPoAuthLib/tree/master/src/OAuth/Common/Storage).
+The `Storage` attribute is optional and defaults to `Session`. In addition to the 
+[other options](https://github.com/Lusitanian/PHPoAuthLib/tree/master/src/OAuth/Common/Storage)
+provided by PHPoAuthLib, there is an additional session driver called `LaravelSession` which will use whatever is configured for Laravels own session driver.
 
 ## Usage
 

--- a/src/Artdarek/OAuth/Common/Storage/LaravelSession.php
+++ b/src/Artdarek/OAuth/Common/Storage/LaravelSession.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Artdarek\OAuth\Common\Storage;
+
+use OAuth\Common\Token\TokenInterface;
+use OAuth\Common\Storage\TokenStorageInterface;
+use OAuth\Common\Storage\Exception\TokenNotFoundException;
+use OAuth\Common\Storage\Exception\AuthorizationStateNotFoundException;
+use Illuminate\Support\Facades\Session;
+
+/**
+ * Stores a token in a Laravel session.
+ */
+class LaravelSession implements TokenStorageInterface
+{
+
+    /**
+     * @var string
+     */
+    protected $sessionNamespace;
+
+    /**
+     * @var string
+     */
+    protected $sessionVariableName;
+
+    /**
+     * @var string
+     */
+    protected $stateVariableName;
+
+    /**
+     * @param string $sessionNamespace prefix to Laravel sessions before dot notation
+     * @param string $sessionVariableName the variable name to use within Laravel session
+     * @param string $stateVariableName
+     */
+    public function __construct(
+        $sessionNamespace = 'lusitanian',
+        $sessionVariableName = 'oauth_token',
+        $stateVariableName = 'oauth_state'
+    ) {
+
+        $this->sessionNamespace = $sessionNamespace;
+        $this->sessionVariableName = $sessionNamespace.'.'.$sessionVariableName;
+        $this->stateVariableName = $sessionNamespace.'.'.$stateVariableName;
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveAccessToken($service)
+    {
+        if ($this->hasAccessToken($service)) {
+            return Session::get($this->sessionVariableName.'.'.$service);
+        }
+
+        throw new TokenNotFoundException('Token not found in session, are you sure you stored it?');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function storeAccessToken($service, TokenInterface $token)
+    {
+        Session::put($this->sessionVariableName.".".$service, $token);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAccessToken($service)
+    {
+        $token = Session::get($this->sessionVariableName.'.'.$service);
+        return !empty($token);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearToken($service)
+    {
+        Session::forget($this->sessionVariableName . '.' . $service);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAllTokens()
+    {
+        Session::forget($this->sessionVariableName);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function storeAuthorizationState($service, $state)
+    {
+        Session::put($this->stateVariableName.'.'.$service, $state);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasAuthorizationState($service)
+    {
+        $state = Session::get($this->stateVariableName.'.'.$service);
+        return !empty($state);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function retrieveAuthorizationState($service)
+    {
+        if ($this->hasAuthorizationState($service)) {
+            return Session::get($this->stateVariableName.'.'.$service);
+        }
+
+        throw new AuthorizationStateNotFoundException('State not found in session, are you sure you stored it?');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAuthorizationState($service)
+    {
+        Session::forget($this->stateVariableName.'.'.$service);
+
+        // allow chaining
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function clearAllAuthorizationStates()
+    {
+        Session::forget($this->stateVariableName);
+
+        // allow chaining
+        return $this;
+    }
+
+    public function __destruct()
+    {
+
+    }
+}

--- a/src/Artdarek/OAuth/OAuth.php
+++ b/src/Artdarek/OAuth/OAuth.php
@@ -75,7 +75,7 @@ class OAuth
             $this->_client_secret = Config::get("oauth-4-laravel.consumers.$service.client_secret");
             $this->_scope = Config::get("oauth-4-laravel.consumers.$service.scope", array() );
 
-        // esle try to find config in packages configs
+        // else try to find config in packages configs
         } else {
             $this->_storage_name = Config::get('oauth-4-laravel::storage', 'Session');
             $this->_client_id = Config::get("oauth-4-laravel::consumers.$service.client_id");
@@ -88,11 +88,15 @@ class OAuth
      * Create storage instance
      *
      * @param string $storageName
-     * @return OAuth\Common\\Storage
+     * @return \OAuth\Common\Storage
      */
     public function createStorageInstance($storageName)
     {
-        $storageClass = "\\OAuth\\Common\\Storage\\$storageName";
+        if ($storageName == "LaravelSession") {
+            $storageClass = "\\Artdarek\\OAuth\\Common\\Storage\\$storageName";
+        } else {
+            $storageClass = "\\OAuth\\Common\\Storage\\$storageName";
+        }
         $storage = new $storageClass();
 
         return $storage;


### PR DESCRIPTION
This pull request creates a new custom driver extending the same TokenStorageInterface as the other session drivers provided by PHPoAuthLib.  It simply replaces all the methods to utilize Laravel's own Session's.
Unlike #78 it maintains compatibility with existing drivers and won't affect anyone currently using the package.